### PR TITLE
Add database.js to server directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/core": "^7.4.4",
     "body-parser": "^1.19.0",
     "express": "^4.17.0",
+    "pg-promise": "^8.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "webpack": "^4.31.0",

--- a/server/database.js
+++ b/server/database.js
@@ -1,0 +1,6 @@
+const pg = require('pg-promise')({});
+
+const uri = 'postgres://ltdnkwnbccooem:64ad308e565b39cc070194f7fa621ae0e925339be5a1c69480ff2a4462eab4c4@ec2-54-163-226-238.compute-1.amazonaws.com:5432/ddsu160rb5t7vq?ssl=true';
+const db = pg(uri);
+
+module.exports = db;

--- a/server/server.js
+++ b/server/server.js
@@ -2,6 +2,10 @@ const express = require('express');
 const path = require('path');
 const bodyParser = require('body-parser');
 const projectController = require('./controllers/projectController.js');
+const db = require('./database');
+
+// Example query to show database is connected
+// db.any(`SELECT * FROM nodes`).then(data => console.log(data));
 
 const app = express();
 
@@ -16,3 +20,4 @@ app.post('/newproject', projectController.newProject);
 app.get('*', (req, res) => res.sendFile(path.join(__dirname, './../index.html')));
 
 app.listen(3000, () => console.log('Listening on port 3000...'));
+


### PR DESCRIPTION
I must’ve missed this in my previous PR—but now `database.js` is in the `/server` directory so you can just import `db` as needed in controllers, etc.